### PR TITLE
Replace `duplexify` and friends with `readable-stream` v4

### DIFF
--- a/guest.js
+++ b/guest.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const { AbstractLevel, AbstractIterator } = require('abstract-level')
-const lpstream = require('length-prefixed-stream')
+const lpstream = require('@vweevers/length-prefixed-stream')
 const ModuleError = require('module-error')
 const { input, output } = require('./tags')
-const { Duplex, pipeline, finished } = require('stream')
+const { Duplex, pipeline, finished } = require('readable-stream')
 
 const kExplicitClose = Symbol('explicitClose')
 const kAbortRequests = Symbol('abortRequests')

--- a/host.js
+++ b/host.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const lpstream = require('length-prefixed-stream')
+const lpstream = require('@vweevers/length-prefixed-stream')
 const ModuleError = require('module-error')
-const { Duplex, finished } = require('stream')
+const { Duplex, finished } = require('readable-stream')
 const { input, output } = require('./tags')
 
 const rangeOptions = new Set(['gt', 'gte', 'lt', 'lte'])

--- a/host.js
+++ b/host.js
@@ -2,8 +2,7 @@
 
 const lpstream = require('length-prefixed-stream')
 const ModuleError = require('module-error')
-const eos = require('end-of-stream')
-const duplexify = require('duplexify')
+const { Duplex, finished } = require('stream')
 const { input, output } = require('./tags')
 
 const rangeOptions = new Set(['gt', 'gte', 'lt', 'lte'])
@@ -60,7 +59,7 @@ function createRpcStream (db, options, streamOptions) {
   const readonly = options.readonly
   const decode = lpstream.decode()
   const encode = lpstream.encode()
-  const stream = duplexify(decode, encode)
+  const stream = Duplex.from({ writable: decode, readable: encode })
 
   const preput = options.preput
   const predel = options.predel
@@ -85,7 +84,7 @@ function createRpcStream (db, options, streamOptions) {
 
     const iterators = new Map()
 
-    eos(stream, function () {
+    finished(stream, function () {
       for (const iterator of iterators.values()) {
         iterator.close()
       }

--- a/package.json
+++ b/package.json
@@ -25,10 +25,11 @@
     "UPGRADING.md"
   ],
   "dependencies": {
+    "@vweevers/length-prefixed-stream": "^1.0.0",
     "abstract-level": "^1.0.3",
-    "length-prefixed-stream": "^2.0.0",
     "module-error": "^1.0.2",
-    "protocol-buffers-encodings": "^1.1.0"
+    "protocol-buffers-encodings": "^1.1.0",
+    "readable-stream": "^4.0.0"
   },
   "devDependencies": {
     "@types/readable-stream": "^2.3.13",
@@ -41,7 +42,6 @@
     "memory-level": "^1.0.0",
     "nyc": "^15.1.0",
     "protocol-buffers": "^5.0.0",
-    "readable-stream": "^3.6.0",
     "standard": "^16.0.3",
     "tape": "^5.0.1",
     "ts-standard": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,6 @@
   ],
   "dependencies": {
     "abstract-level": "^1.0.3",
-    "duplexify": "^4.1.1",
-    "end-of-stream": "^1.1.0",
     "length-prefixed-stream": "^2.0.0",
     "module-error": "^1.0.2",
     "protocol-buffers-encodings": "^1.1.0"


### PR DESCRIPTION
Combines #6 and #1. I've [forked `length-prefixed-stream`](https://github.com/vweevers/length-prefixed-stream) to make that use `readable-stream` v4 as well.

Semver-major because the streams exposed here now don't emit duplexify's custom events (prefinish, preend, cork, uncork) although it's unlikely that anyone is using those events (or even `many-level` itself, which is relatively new).

One thing left to do: test against `rave-level` (which also depends on `readable-stream` and failed a test: https://github.com/Level/rave-level/pull/3).

cc @ronag